### PR TITLE
Create additional-build-test-case.prod.yml

### DIFF
--- a/.github/workflows/additional-build-test-case.prod.yml
+++ b/.github/workflows/additional-build-test-case.prod.yml
@@ -1,0 +1,24 @@
+name: Test-Parsing-Version-Number
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  parse-version-number:
+    runs-on: ubuntu-latest
+    outputs:
+      version-no: ${{ steps.parse_version_number.outputs.version_no }}
+    steps:
+    - id: parse_version_number
+      run: |
+        echo "parsing message '${{ github.event.head_commit.message }}'..."
+        VERSION_NUMBER=`echo "${{ github.event.head_commit.message }}" | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1`
+        echo found $VERSION_NUMBER
+        echo "version_no=$VERSION_NUMBER" >> $GITHUB_OUTPUT
+    - name: Verify Version Number
+      if: ${{ steps.parse_version_number.outputs.version_no == '' }}
+      run: |
+        echo No Version-Number found, exiting...
+        exit 1


### PR DESCRIPTION
Idee ist, dass man bereits vor dem Pull gewarnt wird, dass der Versionierungs Parser fehlschlägt.